### PR TITLE
Commitment validation

### DIFF
--- a/model/commitment.go
+++ b/model/commitment.go
@@ -1,0 +1,61 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+)
+
+type CommitmentOption struct {
+	Label    string             `json:"label"`
+	Requires []CommitmentOption `json:"requires,omitempty"`
+}
+
+func ValidateCommitments(commitments []string, rootOptions []CommitmentOption) error {
+	err := validateCommitments(&commitments, rootOptions, false)
+	if err == nil && len(commitments) > 0 {
+		err = fmt.Errorf("commitments \"%s\" not in options", strings.Join(commitments, ", "))
+	}
+	return err
+}
+
+// TODO move to shared utils module
+func indexOf(s []string, v string) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == v {
+			return i
+		}
+	}
+	return -1
+}
+
+// TODO move to shared utils module
+func remove(s *[]string, i int) {
+	(*s)[i] = (*s)[len(*s)-1]
+	*s = (*s)[:len(*s)-1]
+}
+
+func validateCommitments(commitments *[]string, rootOptions []CommitmentOption, requireAll bool) (err error) {
+	if len(rootOptions) == 1 {
+		// Is root (of subtree)
+		option := rootOptions[0]
+		if i := indexOf(*commitments, option.Label); i != -1 {
+			remove(commitments, i)
+			// Validate branches
+			err = validateCommitments(commitments, option.Requires, true)
+		} else if requireAll {
+			err = fmt.Errorf("required commitment \"%s\"", option.Label)
+		} else {
+			// Validate branches
+			err = validateCommitments(commitments, option.Requires, false)
+		}
+	} else {
+		// Are branches
+		for _, option := range rootOptions {
+			err = validateCommitments(commitments, []CommitmentOption{option}, requireAll)
+			if err != nil {
+				break
+			}
+		}
+	}
+	return
+}

--- a/model/commitment_test.go
+++ b/model/commitment_test.go
@@ -1,0 +1,72 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	jsonCommitmentOptions = []byte(`[
+        {
+            "label": "5/7 days a week"
+        },
+        {
+            "label": "vegan",
+            "requires": [
+                {
+                    "label": "vegetarian",
+                    "requires": [
+                        {
+                            "label": "pescatarian"
+                        },
+                        {
+                            "label": "no beef"
+                        }
+                    ]
+                },
+                {
+                    "label": "no dairy",
+                    "requires": [
+                        {
+                            "label": "no cheese"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]`)
+	validCommitments          = []string{"vegetarian", "pescatarian", "no beef"}
+	invalidCommitmentsMissing = []string{"vegan", "vegetarian", "pescatarian", "no beef"}
+	invalidCommitmentsUnknown = []string{"only caviar"}
+)
+
+func TestCommitments(t *testing.T) {
+	t.Run("Deserialize commitment options from JSON", func(t *testing.T) {
+		var options []CommitmentOption
+		err := json.Unmarshal(jsonCommitmentOptions, &options)
+		assert.Nil(t, err)
+	})
+
+	t.Run("Valid commitment", func(t *testing.T) {
+		var options []CommitmentOption
+		json.Unmarshal(jsonCommitmentOptions, &options)
+		err := ValidateCommitments(validCommitments, options)
+		assert.Nil(t, err)
+	})
+
+	t.Run("Required commitments missing", func(t *testing.T) {
+		var options []CommitmentOption
+		json.Unmarshal(jsonCommitmentOptions, &options)
+		err := ValidateCommitments(invalidCommitmentsMissing, options)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("Invalid commitment", func(t *testing.T) {
+		var options []CommitmentOption
+		json.Unmarshal(jsonCommitmentOptions, &options)
+		err := ValidateCommitments(invalidCommitmentsUnknown, options)
+		assert.NotNil(t, err)
+	})
+}

--- a/model/commitment_test.go
+++ b/model/commitment_test.go
@@ -19,10 +19,12 @@ var (
                     "label": "vegetarian",
                     "requires": [
                         {
-                            "label": "pescatarian"
-                        },
-                        {
-                            "label": "no beef"
+                            "label": "pescatarian",
+							"requires": [
+								{
+									"label": "no beef"
+								}
+							]
                         }
                     ]
                 },


### PR DESCRIPTION
Idea for how to implement commitments for crowdactions.  
**Please discuss! :)**

Crowdactions would have an additional field `commitmentOptions` which would look something like this:
```
[
   {
      "label":"5/7 days a week"
   },
   {
      "label":"vegan",
      "requires":[
         {
            "label":"vegetarian",
            "requires":[
               {
                  "label":"pescatarian",
                  "requires":[
                     {
                        "label":"no beef"
                     }
                  ]
               }
            ]
         },
         {
            "label":"no dairy",
            "requires":[
               {
                  "label":"no cheese"
               }
            ]
         }
      ]
   }
]
```

A user would submit a list of commitments. For each commitment, all branches must be included as well.
For example `["vegetarian", "pescatarian", "no beef"]` and not `["vegan", "vegetarian", "pescatarian", "no beef"]`, because the subtree `no dairy` would be missing.